### PR TITLE
[Parvathy, Rahul] | BAH-3170 | Add. Latest Stable Packages For Security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.springframework.boot' version '2.7.9'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot' version '2.7.14'
+    id 'io.spring.dependency-management' version '1.1.3'
     id 'java'
     id "org.sonarqube" version "3.0"
     id 'jacoco'
@@ -40,34 +40,34 @@ sonarqube {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    implementation 'org.springframework.boot:spring-boot-starter-amqp'
-    implementation 'org.springframework:spring-context-support'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'io.vertx:vertx-pg-client:4.1.5'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.14'
+    implementation 'org.springframework.boot:spring-boot-starter-amqp:2.7.14'
+    implementation 'org.springframework:spring-context-support:5.3.20'
+    implementation 'org.springframework.boot:spring-boot-starter-security:2.7.14'
+    implementation 'io.vertx:vertx-pg-client:4.1.6'
     implementation group: 'com.ongres.scram', name: 'client', version: '2.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.17.1'
-    implementation 'org.apache.logging.log4j:log4j-api:2.17.1'
-    implementation 'com.google.guava:guava:29.0-jre'
-    implementation 'org.springframework.boot:spring-boot-starter-validation'
-    compileOnly 'org.projectlombok:lombok'
-    implementation 'org.bouncycastle:bcprov-jdk15on:1.66'
-    annotationProcessor 'org.projectlombok:lombok'
-    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+    implementation 'org.apache.logging.log4j:log4j-core:2.19.0'
+    implementation 'org.apache.logging.log4j:log4j-api:2.19.0'
+    implementation 'com.google.guava:guava:32.0.1-jre'
+    implementation 'org.springframework.boot:spring-boot-starter-validation:2.7.14'
+    compileOnly 'org.projectlombok:lombok:1.18.22'
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
+    annotationProcessor 'org.projectlombok:lombok:1.18.22'
+    testImplementation('org.springframework.boot:spring-boot-starter-test:2.7.14') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
-    testImplementation "com.squareup.okhttp3:okhttp:4.8.0"
-    testImplementation "com.squareup.okhttp3:mockwebserver:4.8.0"
+    testImplementation "com.squareup.okhttp3:okhttp:4.11.0"
+    testImplementation "com.squareup.okhttp3:mockwebserver:4.11.0"
     testImplementation 'io.projectreactor:reactor-test'
     testImplementation 'org.jeasy:easy-random-core:4.2.0'
-    implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:6.4.1'
-    implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.4.1'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.12'
+    implementation 'ca.uhn.hapi.fhir:hapi-fhir-base:6.4.3'
+    implementation 'ca.uhn.hapi.fhir:hapi-fhir-structures-r4:6.4.3'
+    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'com.nimbusds:nimbus-jose-jwt:8.19'
     implementation 'org.passay:passay:1.6.0'
     implementation 'io.vavr:vavr:0.10.3'
     implementation 'io.lettuce:lettuce-core:5.3.2.RELEASE'
-    implementation 'org.springframework.data:spring-data-redis'
+    implementation 'org.springframework.data:spring-data-redis:2.7.15'
     implementation 'net.logstash.logback:logstash-logback-encoder:6.4'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,8 @@ dependencies {
     implementation 'io.lettuce:lettuce-core:5.3.2.RELEASE'
     implementation 'org.springframework.data:spring-data-redis:2.7.15'
     implementation 'net.logstash.logback:logstash-logback-encoder:6.4'
+    implementation 'org.yaml:snakeyaml:2.0'
+    implementation 'com.squareup.okio:okio:3.4.0'
 }
 
 test {

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.16.1_1-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.19_7-alpine
 VOLUME /tmp
 COPY build/libs/*-SNAPSHOT.jar app.jar
 EXPOSE 8080

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.19_7-alpine
+FROM adoptopenjdk/openjdk11:jre-11.0.20_8
 VOLUME /tmp
 COPY build/libs/*-SNAPSHOT.jar app.jar
 EXPOSE 8080

--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jre-11.0.20_8
+FROM adoptopenjdk/openjdk11:jre-11.0.19_7-alpine
 VOLUME /tmp
 COPY build/libs/*-SNAPSHOT.jar app.jar
 EXPOSE 8080


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

Base Image Update: The base image adoptopenjdk/openjdk11 has been upgraded from version jre-11.0.16.1_1-alpine to version jre-11.0.19_7-alpine.
Dependency Update: A few dependencies have been updated to their immediate stable versions.

This would fix most of our vulnerabilities except the following :
<img width="1728" alt="Screenshot 2023-08-30 at 2 55 35 PM" src="https://github.com/BahmniIndiaDistro/health-information-user/assets/121226043/8515df2f-1d12-47e0-887c-1377bbc9396d">
There is no direct fix for the above vulnerabilities and further investigation needs to be done for the above vulnerabilities.